### PR TITLE
Add command line parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.0"
+structopt = "0.3.2"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use structopt::StructOpt;
 
 /// Generate and Manage targets in your makefiles.
 ///
-/// Makectl is a command line tool to generate and manage general use targets in your makefiles.
+/// Makectl is a command-line tool to generate and manage general use targets in your makefiles.
 #[derive(StructOpt)]
 #[structopt(name = "makectl")]
 pub struct Config {
@@ -13,14 +13,14 @@ pub struct Config {
 #[derive(StructOpt)]
 #[structopt()]
 pub enum Command {
-    /// Add the provided templates into the Makefile.
+    /// Adds the provided templates into the Makefile.
     Add(AddParams),
 }
 
 #[derive(StructOpt)]
 #[structopt(about = "makectl add command parameters")]
 pub struct AddParams {
-    /// List of templates to apply into the Makefile.
+    /// List of templates to apply to the Makefile.
     #[structopt(name = "templates", long = "template", short = "t", required = true)]
     pub templates: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
 #[structopt()]
 pub enum Command {
     /// Add the provided templates into the Makefile.
-    Add(AddParams)
+    Add(AddParams),
 }
 
 #[derive(StructOpt)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,26 @@
+use structopt::StructOpt;
+
+/// Generate and Manage targets in your makefiles.
+///
+/// Makectl is a command line tool to generate and manage general use targets in your makefiles.
+#[derive(StructOpt)]
+#[structopt(name = "makectl")]
+pub struct Config {
+    #[structopt(subcommand)]
+    pub command: Command,
+}
+
+#[derive(StructOpt)]
+#[structopt()]
+pub enum Command {
+    /// Add the provided templates into the Makefile.
+    Add(AddParams)
+}
+
+#[derive(StructOpt)]
+#[structopt(about = "makectl add command parameters")]
+pub struct AddParams {
+    /// List of templates to apply into the Makefile.
+    #[structopt(name = "templates", long = "template", short = "t", required = true)]
+    pub templates: Vec<String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod config;
 
 use structopt::StructOpt;
 
-use crate::config::{Config, Command};
+use crate::config::{Command, Config};
 
 fn main() {
     let conf = Config::from_args();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,15 @@
+mod config;
+
+use structopt::StructOpt;
+
+use crate::config::{Config, Command};
+
 fn main() {
-    println!("Hello, world!");
+    let conf = Config::from_args();
+
+    match conf.command {
+        Command::Add(ref add_params) => {
+            println!("Add command invoked with: {:?}", add_params.templates);
+        }
+    }
 }


### PR DESCRIPTION
This is a base for a CLI parameter handling implemented using StructOpt instead of Clap directly.

Related Issue: #1

----

```
➜ makectl add-config ✓ cargo run -- -h                 
makectl 0.1.0
Generate and Manage targets in your makefiles.

Makectl is a command-line tool to generate and manage general use targets in your makefiles.

USAGE:
    makectl <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    add     Adds the provided templates into the Makefile.
    help    Prints this message or the help of the given subcommand(s)
```

```
➜ makectl add-config ✓ cargo run -- add -h             
makectl-add 0.1.0
Adds the provided templates into the Makefile.

USAGE:
    makectl add --template <templates>...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -t, --template <templates>...    List of templates to apply to the Makefile.
```

```
➜ makectl add-config ✓ cargo run -- add -t python -t go
Add command invoked with: ["python", "go"]
```